### PR TITLE
Fixed crashing of dialogs.

### DIFF
--- a/gc2d/controller/action/open_choose_palette_action.py
+++ b/gc2d/controller/action/open_choose_palette_action.py
@@ -3,6 +3,7 @@ from PyQt5.QtWidgets import QAction
 
 from gc2d.controller.dialogs.palette_chooser import PaletteChooser
 
+
 class OpenChoosePaletteAction(QAction):
 
     def __init__(self, parent, model_wrapper):
@@ -12,7 +13,6 @@ class OpenChoosePaletteAction(QAction):
         """
         super().__init__('Choose Palette', parent)
         self.model_wrapper = model_wrapper
-        self.dialog = None
         self.setShortcut('Ctrl+Shift+C')
         self.setStatusTip('Opens the Choose Palette Dialog')
         self.triggered.connect(self.show_dialog)
@@ -23,18 +23,7 @@ class OpenChoosePaletteAction(QAction):
         Show the Choose Palette dialog.
         :return: None
         """
-        
-        if self.dialog is None:
-            self.dialog = PaletteChooser(self.on_select, self.on_close)
-            self.parent().dialogs.append(self.dialog)
-        
-        self.dialog.show()
-        self.dialog.raise_()
-        self.dialog.activateWindow()
+        self.parent().addDialog(PaletteChooser(self.on_select))
 
     def on_select(self, palette):
         self.model_wrapper.set_palette(palette)
-
-    def on_close(self):
-        self.parent().dialogs.remove(self.dialog)
-        self.dialog = None

--- a/gc2d/controller/dialogs/palette_chooser.py
+++ b/gc2d/controller/dialogs/palette_chooser.py
@@ -3,9 +3,10 @@ from PyQt5.QtWidgets import QHBoxLayout, QLabel, QLayout, QListWidget, QListWidg
 
 from gc2d.view.palette.palette import Palette
 
+
 class PaletteChooser(QMainWindow):
     
-    def __init__(self, on_select, on_close):
+    def __init__(self, on_select):
         """
         This window will open a palettle chooser to let users select a palette from the (global) list of possible palettes.
         :param on_select: A callback function that is called when a palette is selected.
@@ -15,9 +16,8 @@ class PaletteChooser(QMainWindow):
         
         super().__init__(parent=None)
         self.setWindowTitle("Choose Palette")
-        
+
         self.on_select = on_select
-        self.on_close = on_close
 
         vbox = QWidget()
         self.setCentralWidget(vbox)
@@ -64,11 +64,7 @@ class PaletteChooser(QMainWindow):
         self.on_select(Palette.palettes[index])
         self.close()
 
-
     def closeEvent(self, event):
         """ Overrides the closing event to execute the on_close callback after closing.
         This is better than overriding close() because this will also execute when the user presses the x button on the top of the window."""
         event.accept()
-        self.on_close()
-    
-

--- a/gc2d/view/main_window.py
+++ b/gc2d/view/main_window.py
@@ -111,3 +111,18 @@ class Window(QMainWindow):
         dock_list = Dock('integration')
         dock_area.addDock(dock_list)
         dock_list.addWidget(IntegrationList(self.model_wrapper, dock_list))
+
+    def addDialog(self, dialog):
+        for d in self.dialogs:
+            if isinstance(d, type(dialog)):
+                d.show()
+                d.raise_()
+                d.activateWindow()
+                d.showNormal()
+                return
+
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+        dialog.showNormal()
+        self.dialogs.append(dialog)


### PR DESCRIPTION
This will fix the palette crashing the dialogs. Dunno why dialogs are using QMainWindow. QDialog may be better? I'll look into that later.