### PR TITLE
Disable transformations and draw without model

### DIFF
--- a/gc2d/controller/action/draw_action.py
+++ b/gc2d/controller/action/draw_action.py
@@ -16,6 +16,10 @@ class DrawAction(QAction):
         self.model_wrapper = model_wrapper
         self.setShortcut('Ctrl+D')
         self.setStatusTip('Select integration area')
+
+        self.setEnabled(self.model_wrapper.model is not None)
+        self.model_wrapper.add_observer(self, self.notify)
+
         self.triggered.connect(self.draw)
 
     def draw(self):
@@ -25,3 +29,7 @@ class DrawAction(QAction):
         """
         if self.model_wrapper.model is not None:
             Selector(self.model_wrapper)
+
+    def notify(self, name, value):
+        if name == 'model':
+            self.setEnabled(value is not None)

--- a/gc2d/controller/action/open_convolution_picker_action.py
+++ b/gc2d/controller/action/open_convolution_picker_action.py
@@ -14,6 +14,8 @@ class OpenConvolutionPickerAction(QAction):
         super().__init__('Set Transformation', parent)
         self.model_wrapper = model_wrapper
         self.dialog = None
+        self.setEnabled(self.model_wrapper.model is not None)
+        self.model_wrapper.add_observer(self, self.notify)
         self.triggered.connect(self.show_dialog)
 
     def show_dialog(self):
@@ -26,3 +28,6 @@ class OpenConvolutionPickerAction(QAction):
     def on_select(self, transform):
         self.model_wrapper.set_transform(transform)
 
+    def notify(self, name, value):
+        if name == 'model':
+            self.setEnabled(value is not None)

--- a/gc2d/controller/action/toggle_convolution_action.py
+++ b/gc2d/controller/action/toggle_convolution_action.py
@@ -11,7 +11,10 @@ class ToggleConvolutionAction(QAction):
         super().__init__('Show transformed data', parent, checkable=True)
         self.model_wrapper = model_wrapper
         self.toggled.connect(self.update)
+
+        self.setEnabled(self.model_wrapper.model is not None)
         self.model_wrapper.add_observer(self, self.notified)
+
         self.setChecked(True)
 
     def update(self):
@@ -20,5 +23,6 @@ class ToggleConvolutionAction(QAction):
     
     def notified(self, name, model):
         if name == 'model':
+            self.setEnabled(model is not None)
             self.update()
         


### PR DESCRIPTION
Disabled the actions for transformations and draw when no model is loaded.