### PR TITLE
Fixed scaling ROI's

### DIFF
--- a/gc2d/controller/integration/selector.py
+++ b/gc2d/controller/integration/selector.py
@@ -31,6 +31,7 @@ class Selector(QObject):
         :return: None
         """
         pen = self.model_wrapper.get_preference(PreferenceEnum.PEN)
+        pen.setCosmetic(True)
         if handles == None:
             self.roi = PolyLineROI([[80, 60], [90, 30], [60, 40]], pos=(100,100), pen=pen, closed=True)
         else: 


### PR DESCRIPTION
Did a little digging and found that `QPen.setCosmetic(True)` will stop the scaling. The alternative is 0 width QPens, however that'll make them 1px wide.