### PR TITLE
name of project as window title, if set

### DIFF
--- a/gc2d/view/main_window.py
+++ b/gc2d/view/main_window.py
@@ -161,5 +161,5 @@ class Window(QMainWindow):
         self.dialogs.append(dialog)
 
     def notify(self, name, value):
-        if name == PreferenceEnum.SAVE_FILE.name:
+        if name == PreferenceEnum.SAVE_FILE.name and value is not None:
             self.setWindowTitle(os.path.basename(value).split(".")[0])


### PR DESCRIPTION
Small thing: looks good and is handy for knowing in which file you're busy, as suggested in #75 